### PR TITLE
Enable PHP 7.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "Disable Newsletter Magento 2"
     ],
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0"
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0"
     },
     "type": "magento2-module",
     "version": "1.0.0",


### PR DESCRIPTION
Add support for PHP 7.1 - we tried it with a Magento 2.2 B2B install on PHP 7.1.9 and it works